### PR TITLE
opts.filename instead of log.filename

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13,7 +13,7 @@ function assignDescriptionToSymbol(node, name, file) {
 
 function generateDescription(name, file) {
   if (file && file.opts && file.opts.filename && file.opts.filename !== 'unknown') {
-    var basename = path.basename(file.log.filename).split('.')[0];
+    var basename = path.basename(file.opts.filename).split('.')[0];
     return basename + '.' + name;
   } else {
     return name;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-auto-symbol-description",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Babel plugin to automatically set Symbol descriptions.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Was this a typo or am I missing a distinction?

I was trying to use this with babel 7 and ran into an error here.